### PR TITLE
Refactor layout with sidebar and project cards

### DIFF
--- a/src/components/ProjectCard.css
+++ b/src/components/ProjectCard.css
@@ -1,0 +1,58 @@
+.project-card {
+  background-color: #1a1a1a;
+  border: 1px solid #333;
+  padding: 1rem;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.project-card-img {
+  width: 100%;
+  border-radius: 4px;
+  object-fit: cover;
+}
+
+.project-card-title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.project-card-desc {
+  font-size: 0.9rem;
+}
+
+.project-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.tag {
+  background-color: #333;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+.project-card-links {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.project-card-button {
+  background-color: #222;
+  border: 1px solid #555;
+  color: #fff;
+  padding: 0.3rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.project-card-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,39 @@
+import { motion } from 'framer-motion';
+import './ProjectCard.css';
+
+export interface ProjectData {
+  id: number;
+  title: string;
+  description: string;
+  image: string;
+  skills?: string[];
+  links?: { name: string; link: string }[];
+}
+
+export default function ProjectCard({ project }: { project: ProjectData }) {
+  return (
+    <motion.div className="project-card" whileHover={{ scale: 1.02 }}>
+      <img src={project.image} alt={project.title} className="project-card-img" />
+      <h3 className="project-card-title">{project.title}</h3>
+      <p className="project-card-desc">{project.description}</p>
+      {project.skills && (
+        <div className="project-card-tags">
+          {project.skills.map((skill, idx) => (
+            <span className="tag" key={idx}>{skill}</span>
+          ))}
+        </div>
+      )}
+      {project.links && (
+        <div className="project-card-links">
+          {project.links.map((link, idx) => (
+            link.link === 'n/a' ? (
+              <button className="project-card-button" key={idx} disabled>{link.name}</button>
+            ) : (
+              <button className="project-card-button" key={idx} onClick={() => window.open(link.link, '_blank')}>{link.name}</button>
+            )
+          ))}
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/src/components/Sidebar.css
+++ b/src/components/Sidebar.css
@@ -1,0 +1,48 @@
+.sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 250px;
+  background-color: #111;
+  color: #f5f5f5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  z-index: 1000;
+}
+
+.profile-img {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 1rem;
+}
+
+.sidebar-nav {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sidebar-nav a {
+  color: inherit;
+  text-decoration: none;
+  font-size: 1rem;
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    flex-direction: row;
+    width: 100%;
+    height: auto;
+    position: static;
+    justify-content: space-between;
+  }
+  .sidebar-nav {
+    flex-direction: row;
+  }
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+import './Sidebar.css';
+
+export default function Sidebar() {
+  return (
+    <aside className="sidebar">
+      <div className="profile">
+        <img src="/harmony.png" alt="Profile" className="profile-img" />
+        <h1 className="profile-name">Mario Peng Lee</h1>
+        <p className="profile-tagline">AI Engineer</p>
+      </div>
+      <nav className="sidebar-nav">
+        <Link to="/">About</Link>
+        <Link to="/projects">Projects</Link>
+        <Link to="/contact">Contact</Link>
+      </nav>
+    </aside>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -102,3 +102,16 @@ b{
   }
  
 }
+
+.content {
+  margin-left: 250px;
+  width: calc(100% - 250px);
+}
+
+@media (max-width: 768px) {
+  .content {
+    margin-left: 0;
+    width: 100%;
+    padding-top: 100px;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { HashRouter, Routes, Route, useLocation } from 'react-router-dom';
-import Navbar from './components/Navbar';
+import Sidebar from './components/Sidebar';
 import Landing from './screens/Landing';
 import Projects from './pages/Projects';
 import Contact from './pages/Contact';
@@ -11,21 +11,21 @@ import { AnimatePresence } from 'framer-motion';
 import './index.css';
 
 const App = () => {
-  const location = useLocation(); // Get the current location
+  const location = useLocation();
 
-
-  
   return (
     <>
-      <Navbar />
-      <CustomCursor />
-      <AnimatePresence mode="wait">
-        <Routes location={location} key={location.pathname}>
-          <Route path="/" element={<Landing />} />
-          <Route path="/projects" element={<Projects />} />
-          <Route path="/contact" element={<Contact />} />
-        </Routes>
-      </AnimatePresence>
+      <Sidebar />
+      <div className="content">
+        <CustomCursor />
+        <AnimatePresence mode="wait">
+          <Routes location={location} key={location.pathname}>
+            <Route path="/" element={<Landing />} />
+            <Route path="/projects" element={<Projects />} />
+            <Route path="/contact" element={<Contact />} />
+          </Routes>
+        </AnimatePresence>
+      </div>
     </>
   );
 };

--- a/src/pages/Projects.css
+++ b/src/pages/Projects.css
@@ -1,69 +1,12 @@
 #projects {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    justify-content: flex-start;
-    height: 100vh;
-    width: 100vw;
-    
-
-
-    .titles{
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        justify-content: flex-start;
-        padding-left: 0.5em;
-        height: 100vh;
-        width: 30vw;
-        overflow-y: scroll;
-        background: linear-gradient(90deg, rgba(0,0,0,1) 60%, rgba(0,0,0,0) 100%);
-        opacity: 0.4;
-        transition: 0.5s ease-in-out;
-        z-index: 1;
-        
-
-    }
-    .titles:hover{
-        opacity: 0.9;
-    }
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
 }
 
-.project-category-title {
-    font-weight: bold;
-    margin-bottom: 0px;
-
-
-}
-
-@media (max-width: 734px) {
-    #projects {
-        display: flex;
-        flex-direction: column;
-        align-items: flex-start;
-        justify-content: flex-start;
-        height: 100vh;
-        width: 100vw;
-
-        .titles{
-            display: flex;
-            flex-direction: column;
-            align-items: flex-start;
-            justify-content: flex-start;
-            padding-left: 0.5em;
-            padding-top: 0.5em;
-            height: calc(30vh - 0.5em);
-            width: 100vw;
-            overflow-y: scroll;
-            background: linear-gradient(180deg, rgba(0,0,0,1) 60%, rgba(0,0,0,0) 100%);
-            opacity: 0.5;
-            z-index: 1;
-            
-    
-        }
-        .titles:hover{
-            opacity: 0.5;
-        }
-    }
-    
+@media (min-width: 768px) {
+  #projects {
+    padding-left: 260px; /* account for sidebar */
+  }
 }

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,120 +1,26 @@
-import { useLayoutEffect, useState } from "react";
-import "./Projects.css";
-import { motion } from "framer-motion";
-import TickerItem from "../components/TickerItem";
-import research from "../data/research.json";
-import gamedev from "../data/gamedev.json";
-import ProjectPanel from "../components/ProjectPanel";
-import { gsap } from "gsap";
+import { motion } from 'framer-motion';
+import './Projects.css';
+import research from '../data/research.json';
+import gamedev from '../data/gamedev.json';
+import ProjectCard, { ProjectData } from '../components/ProjectCard';
 
+const allProjects: ProjectData[] = [...research, ...gamedev];
 
-function Projects() {
-
-  const [selectedId, setSelectedId] = useState(1);
-  console.log(selectedId);
+export default function Projects() {
   const pageVariants = {
-    initial: {
-      x: "100vw",
-      transition: {
-        duration: 1,
-        type: "spring",
-        stiffness: 50
-      }
-    },
-    in: {
-      x: 0,
-      transition: {
-        duration: 1,
-        type: "spring",
-        stiffness: 50
-      }
-      
-    },
-    out: {
-      x: "-100vw",
-      transition: {
-        duration: 1,
-        type: "spring",
-        stiffness: 50
-      }
-      
-    }
+    initial: { x: '100vw' },
+    in: { x: 0 },
+    out: { x: '-100vw' },
   };
+  const pageTransition = { type: 'tween', ease: 'anticipate', duration: 1 };
 
-  const pageTransition = {
-    type: "tween",
-    ease: "anticipate",
-    duration: 1
-  };
-
-  useLayoutEffect(() => {
-    const elements = document.querySelectorAll('.animatable');
-
-
-    gsap.fromTo(elements, {
-      autoAlpha: 0,
-      y: 50,
-    }, {
-      autoAlpha: 1,
-      y: 0,
-      stagger: 0.1,
-      duration: 1,
-      ease: "power2.out",
-      scrollTrigger: {
-        trigger: ".titles",
-        start: "top 80%",
-        end: "bottom 80%",
-        // markers: true
-      }
-    });
-  }, []);
-
-
-  
   return (
-    
-    <motion.div
-    initial="initial"
-    animate="in"
-    exit="out"
-    variants={pageVariants}
-    transition={pageTransition}
-    >
+    <motion.div initial="initial" animate="in" exit="out" variants={pageVariants} transition={pageTransition}>
       <section id="projects">
-        <div className="titles">
-        <p className="project-category-title">Research</p>
-        <div className="ticker">
-        {research.map((project) => (
-        <div key={project.id.toString()}>
-            <TickerItem 
-                project={project} 
-                key={project.id.toString()}
-                setSelectedId={setSelectedId}
-            />
-        </div>
-    ))}
-        </div>
-        <p className="project-category-title">Game Dev</p>
-        <div className="ticker">
-        {gamedev.map((project) => (
-        <div key={project.id.toString()}>
-            <TickerItem 
-                project={project} 
-                key={project.id.toString()}
-                setSelectedId={setSelectedId}
-            />
-        </div>
-    ))}
-      </div>
-      </div>
-          <ProjectPanel
-              projectId={selectedId}
-              otherProject={selectedId > 10}
-          />
+        {allProjects.map((project) => (
+          <ProjectCard project={project} key={project.id} />
+        ))}
       </section>
-      
     </motion.div>
   );
 }
-
-export default Projects;


### PR DESCRIPTION
## Summary
- add `Sidebar` component for profile and nav
- create `ProjectCard` component
- refactor `Projects` page to display cards in a grid
- adjust main layout and styles for sidebar content

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6884d332500c8325a8c38073a78ef84a